### PR TITLE
Fix :  A1,2 and 3 memory bugs

### DIFF
--- a/Indicateurs_IQM/calcul_a1.py
+++ b/Indicateurs_IQM/calcul_a1.py
@@ -1,4 +1,5 @@
-
+from tempfile import NamedTemporaryFile as Ntf
+import os
 import processing
 from qgis.PyQt.QtCore import QVariant, QCoreApplication
 from qgis.core import (QgsProcessing,
@@ -43,7 +44,7 @@ class IndiceA1(QgsProcessingAlgorithm):
 
 		# Dictionnary that will contain all temporary file locations
 		tmp = {}
-		tmp['watershed'] = Ntf(suffix="watershed.tif")
+		tmp['watershed'] = Ntf(suffix="watershed.tif", delete=False)
 
 		# Define source stream net
 		source = self.parameterAsSource(parameters, 'stream_network', context)
@@ -182,7 +183,7 @@ class IndiceA1(QgsProcessingAlgorithm):
 			outputs['Drain_areaLand_use'] = processing.run('gdal:cliprasterbymasklayer', alg_params, context=context, feedback=feedback, is_child_algorithm=True)
 
 			# Landuse unique values report
-			tmp['table'] = Ntf(suffix="table")
+			tmp['table'] = Ntf(suffix="table", delete=False)
 			alg_params = {
 				'BAND': 1,
 				'INPUT': outputs['Drain_areaLand_use']['OUTPUT'],
@@ -237,6 +238,7 @@ class IndiceA1(QgsProcessingAlgorithm):
 		# Clear temporary files
 		for tempfile in tmp.values():
 			tempfile.close()
+			os.remove(tempfile.name)
 
 		return {self.OUTPUT : dest_id}
 

--- a/Indicateurs_IQM/calcul_a2.py
+++ b/Indicateurs_IQM/calcul_a2.py
@@ -1,5 +1,6 @@
 
 from tempfile import NamedTemporaryFile as Ntf
+import os
 from qgis.PyQt.QtCore import QVariant, QCoreApplication
 from qgis.core import (QgsProcessing,
 					   QgsField,
@@ -36,8 +37,8 @@ class IndiceA2(QgsProcessingAlgorithm):
 
 		# Create temporary file locations
 		tmp = {
-			'mainWatershed' : Ntf(suffix="watershed.tif"),
-			'subWatershed' : Ntf(suffix="sub-watershed.tif"),
+			'mainWatershed' : Ntf(suffix="watershed.tif", delete=False),
+			'subWatershed' : Ntf(suffix="sub-watershed.tif", delete=False),
 		}
 
 		# Define source stream net
@@ -199,6 +200,7 @@ class IndiceA2(QgsProcessingAlgorithm):
 		# Clear temporary files
 		for tempfile in tmp.values():
 			tempfile.close()
+			os.remove(tempfile.name)
 
 		return {self.OUTPUT: dest_id}
 

--- a/Indicateurs_IQM/calcul_a3.py
+++ b/Indicateurs_IQM/calcul_a3.py
@@ -5,6 +5,7 @@ Group :
 With QGIS : 32601
 """
 from tempfile import NamedTemporaryFile as Ntf
+import os
 from qgis.PyQt.QtCore import QVariant, QCoreApplication
 from qgis.core import (QgsProcessing,
                         QgsField,
@@ -48,9 +49,9 @@ class IndiceA3(QgsProcessingAlgorithm):
 
         # Create temporary file locations
         tmp = {
-            'table':Ntf(suffix="table"),
-            'buffer':Ntf(suffix="buffer"),
-            'mainWatershed':Ntf(suffix="watershed.tif"),
+            'table':Ntf(suffix="table", delete=False),
+            'buffer':Ntf(suffix="buffer", delete=False),
+            'mainWatershed':Ntf(suffix="watershed.tif", delete=False),
         }
 
         # Define source stream net
@@ -187,7 +188,7 @@ class IndiceA3(QgsProcessingAlgorithm):
                 'JOIN_STYLE':0,'MITER_LIMIT':2,
                 'DISSOLVE':True,
                 #'OUTPUT':f"tmp/buffer{fid}.gpkg"
-                'OUTPUT':tmp['buffer'].name
+                'OUTPUT': QgsProcessing.TEMPORARY_OUTPUT
             }
             outputs['damBuffer'] = processing.run("native:buffer", alg_params, context=context, feedback=feedback, is_child_algorithm=True)
 
@@ -289,6 +290,7 @@ class IndiceA3(QgsProcessingAlgorithm):
         # Clear temporary files
         for tempfile in tmp.values():
             tempfile.close()
+            os.remove(tempfile.name)
 
         return {self.OUTPUT: dest_id}
 


### PR DESCRIPTION
Closes issue #8. Bugs were due to an import statement omission and because the delete parameter of the NamedTemporaryFile was not given which closed them after they were opened. I added the os.remove too to close the temporary files otherswise it would lead to memory overuse.